### PR TITLE
Fix bug with flipping causing reflection instead of flipping

### DIFF
--- a/CardFlip.js
+++ b/CardFlip.js
@@ -12,7 +12,7 @@ export default class CardFlip extends Component<Props> {
 
   constructor(props) {
     super(props);
-    this.state ={
+    this.state = {
       duration: 5000,
       side: 0,
       sides: [],
@@ -21,7 +21,7 @@ export default class CardFlip extends Component<Props> {
       zoom: new Animated.Value(0),
       rotateOrientation: '',
       flipDirection: 'y'
-    }
+    };
   }
 
   componentDidMount(){
@@ -92,7 +92,7 @@ export default class CardFlip extends Component<Props> {
 
     const defaultConfig = { count: 2, duration: 100, progress: 0.05 };
     const config = { ...defaultConfig, ...customConfig}
-    const { count, duration, progress } = config;
+    const { count, duration, progress } = config;
 
     const { rotation, side } = this.state;
 
@@ -151,27 +151,25 @@ export default class CardFlip extends Component<Props> {
 
   flipY() {
     const { side }  = this.state;
-    this.setState({
-      side: (side === 0) ? 1 : 0,
-      rotateOrientation: 'y',
-    });
     this._flipTo({
       x: 50,
       y: (side === 0) ? 100 : 50,
+    });
+    this.setState({
+      side: (side === 0) ? 1 : 0,
+      rotateOrientation: 'y',
     });
   }
 
   flipX() {
     const { side }  = this.state;
-
-    this.setState({
-      side: (side === 0) ? 1 : 0,
-      rotateOrientation: 'x',
-    });
-
     this._flipTo({
       y: 50,
       x: (side === 0) ? 100 : 50,
+    });
+    this.setState({
+      side: (side === 0) ? 1 : 0,
+      rotateOrientation: 'x',
     });
   }
 
@@ -308,7 +306,7 @@ export default class CardFlip extends Component<Props> {
   render() {
 
     const { side, progress, rotateOrientation, zoom, sides } = this.state;
-    const { flipZoom } = this.props
+    const { flipZoom } = this.props
 
     // Handle cardA transformation
     const cardATransform = this.getCardATransformation()


### PR DESCRIPTION
In the `flipX`/`flipY` functions, 2 functions are called `setState` and `_flipTo`.

Previously the order was:
1. `setState`
2. `_flipTo`
This works for touch events always because `setState` is put on the event queue and `_flipTo` is called with the old state, so `setState` ends of actually taking effect **after** `_flipTo` is called. However on other events (ex. after an API call callback) if we try to flip the card `setState` is called and takes effect immediately and then `_flipTo` is called. When `_flipTo` is called after the state is updated this ends up messing up the animations and results in the card flipping but presenting a side mirrored (ex. text is backwards).

My simple fix is to change the order to call the functions to:
1. `_flipTo`
2. `setState`

This ensures `_flipTo` is called before the state is changed which is what is intended to happen.