### PR TITLE
Fix uninstantiated bYRotation variable & Lint

### DIFF
--- a/CardFlip.js
+++ b/CardFlip.js
@@ -1,8 +1,8 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
 
-import { Platform, StyleSheet, Animated } from "react-native";
+import { Platform, StyleSheet, Animated } from 'react-native';
 
 class CardFlip extends Component<Props> {
   constructor(props) {
@@ -14,51 +14,51 @@ class CardFlip extends Component<Props> {
       progress: new Animated.Value(0),
       rotation: new Animated.ValueXY({ x: 50, y: 50 }),
       zoom: new Animated.Value(0),
-      rotateOrientation: "",
-      flipDirection: "y"
-    }
+      rotateOrientation: '',
+      flipDirection: 'y',
+    };
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.duration !== prevState.duration ||
+    if (
+      nextProps.duration !== prevState.duration ||
       nextProps.flipZoom !== prevState.flipZoom ||
-      nextProps.children !== prevState.sides) {
+      nextProps.children !== prevState.sides
+    ) {
       return {
         duration: nextProps.duration,
         flipZoom: nextProps.flipZoom,
-        sides: nextProps.children
-      }
+        sides: nextProps.children,
+      };
     }
     return null;
   }
-
 
   componentDidMount() {
     this.setState({
       duration: this.props.duration,
       flipZoom: this.props.flipZoom,
-      sides: this.props.children
+      sides: this.props.children,
     });
   }
 
-
   tip(customConfig) {
-    const defaultConfig = { direction: "left", progress: 0.05, duration: 150 };
+    const defaultConfig = { direction: 'left', progress: 0.05, duration: 150 };
     const config = { ...defaultConfig, ...customConfig };
     const { direction, progress, duration } = config;
 
     const { rotation, side } = this.state;
     const sequence = [];
 
-    if (direction === "right") {
+    if (direction === 'right') {
       sequence.push(
         Animated.timing(rotation, {
           toValue: {
             x: 0,
-            y: side === 0 ? 50 + progress * 50 : 90
+            y: side === 0 ? 50 + progress * 50 : 90,
           },
           duration,
-          useNativeDriver: true
+          useNativeDriver: true,
         })
       );
     } else {
@@ -66,10 +66,10 @@ class CardFlip extends Component<Props> {
         Animated.timing(rotation, {
           toValue: {
             x: 0,
-            y: side === 0 ? 50 - progress * 50 : 90
+            y: side === 0 ? 50 - progress * 50 : 90,
           },
           duration,
-          useNativeDriver: true
+          useNativeDriver: true,
         })
       );
     }
@@ -77,10 +77,10 @@ class CardFlip extends Component<Props> {
       Animated.timing(rotation, {
         toValue: {
           x: 0,
-          y: side === 0 ? 50 : 100
+          y: side === 0 ? 50 : 100,
         },
         duration,
-        useNativeDriver: true
+        useNativeDriver: true,
       })
     );
     Animated.sequence(sequence).start();
@@ -100,10 +100,10 @@ class CardFlip extends Component<Props> {
         Animated.timing(rotation, {
           toValue: {
             x: 0,
-            y: side === 0 ? 50 + progress * 50 : 90
+            y: side === 0 ? 50 + progress * 50 : 90,
           },
           duration,
-          useNativeDriver: true
+          useNativeDriver: true,
         })
       );
 
@@ -111,10 +111,10 @@ class CardFlip extends Component<Props> {
         Animated.timing(rotation, {
           toValue: {
             x: 0,
-            y: side === 0 ? 50 - progress * 50 : 110
+            y: side === 0 ? 50 - progress * 50 : 110,
           },
           duration,
-          useNativeDriver: true
+          useNativeDriver: true,
         })
       );
     }
@@ -122,17 +122,17 @@ class CardFlip extends Component<Props> {
       Animated.timing(rotation, {
         toValue: {
           x: 0,
-          y: side === 0 ? 50 : 100
+          y: side === 0 ? 50 : 100,
         },
         duration,
-        useNativeDriver: true
+        useNativeDriver: true,
       })
     );
     Animated.sequence(sequence).start();
   }
 
   flip() {
-    if (this.props.flipDirection == "y") {
+    if (this.props.flipDirection == 'y') {
       this.flipY();
     } else {
       this.flipX();
@@ -143,11 +143,11 @@ class CardFlip extends Component<Props> {
     const { side } = this.state;
     this._flipTo({
       x: 50,
-      y: side === 0 ? 100 : 50
+      y: side === 0 ? 100 : 50,
     });
     this.setState({
       side: side === 0 ? 1 : 0,
-      rotateOrientation: "y"
+      rotateOrientation: 'y',
     });
   }
 
@@ -155,10 +155,10 @@ class CardFlip extends Component<Props> {
     const { side } = this.state;
     this._flipTo({
       y: 50,
-      x: side === 0 ? 100 : 50
+      x: side === 0 ? 100 : 50,
     });
     this.setState({
-      side: (side === 0) ? 1 : 0,
+      side: side === 0 ? 1 : 0,
       rotateOrientation: 'x',
     });
   }
@@ -171,25 +171,25 @@ class CardFlip extends Component<Props> {
       Animated.timing(progress, {
         toValue: side === 0 ? 100 : 0,
         duration,
-        useNativeDriver: true
+        useNativeDriver: true,
       }),
       Animated.sequence([
         Animated.timing(zoom, {
           toValue: 100,
           duration: duration / 2,
-          useNativeDriver: true
+          useNativeDriver: true,
         }),
         Animated.timing(zoom, {
           toValue: 0,
           duration: duration / 2,
-          useNativeDriver: true
-        })
+          useNativeDriver: true,
+        }),
       ]),
       Animated.timing(rotation, {
         toValue,
         duration: duration,
-        useNativeDriver: true
-      })
+        useNativeDriver: true,
+      }),
     ]).start(() => {
       this.props.onFlipEnd(side === 0 ? 1 : 0);
     });
@@ -202,27 +202,27 @@ class CardFlip extends Component<Props> {
     const sideAOpacity = progress.interpolate({
       inputRange: [50, 51],
       outputRange: [100, 0],
-      extrapolate: "clamp"
+      extrapolate: 'clamp',
     });
 
     const sideATransform = {
       opacity: sideAOpacity,
       zIndex: side === 0 ? 1 : 0,
-      transform: [{ perspective: this.props.perspective }]
+      transform: [{ perspective: this.props.perspective }],
     };
-    if (rotateOrientation === "x") {
+    if (rotateOrientation === 'x') {
       const aXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["-180deg", "0deg", "180deg", "0deg"],
-        extrapolate: "clamp"
+        outputRange: ['-180deg', '0deg', '180deg', '0deg'],
+        extrapolate: 'clamp',
       });
       sideATransform.transform.push({ rotateX: aXRotation });
     } else {
       // cardA Y-rotation
       const aYRotation = rotation.y.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["-180deg", "0deg", "180deg", "0deg"],
-        extrapolate: "clamp"
+        outputRange: ['-180deg', '0deg', '180deg', '0deg'],
+        extrapolate: 'clamp',
       });
       sideATransform.transform.push({ rotateY: aYRotation });
     }
@@ -235,36 +235,37 @@ class CardFlip extends Component<Props> {
     const sideBOpacity = progress.interpolate({
       inputRange: [50, 51],
       outputRange: [0, 100],
-      extrapolate: "clamp"
+      extrapolate: 'clamp',
     });
 
     const sideBTransform = {
       opacity: sideBOpacity,
       zIndex: side === 0 ? 0 : 1,
-      transform: [{ perspective: -1 * this.props.perspective }]
+      transform: [{ perspective: -1 * this.props.perspective }],
     };
 
-    if (rotateOrientation === "x") {
+    if (rotateOrientation === 'x') {
       const bXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["0deg", "-180deg", "-360deg", "180deg"],
-        extrapolate: "clamp"
+        outputRange: ['0deg', '-180deg', '-360deg', '180deg'],
+        extrapolate: 'clamp',
       });
       sideBTransform.transform.push({ rotateX: bXRotation });
     } else {
-      if (Platform.OS === "ios") {
+      let bYRotation;
+      if (Platform.OS === 'ios') {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: ["0deg", "180deg", "0deg", "-180deg"],
-          extrapolate: "clamp"
+          outputRange: ['0deg', '180deg', '0deg', '-180deg'],
+          extrapolate: 'clamp',
         });
       } else {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: ["0deg", "-180deg", "0deg", "180deg"],
-          extrapolate: "clamp"
+          outputRange: ['0deg', '-180deg', '0deg', '180deg'],
+          extrapolate: 'clamp',
         });
       }
       sideBTransform.transform.push({ rotateY: bYRotation });
@@ -286,11 +287,11 @@ class CardFlip extends Component<Props> {
     const cardZoom = zoom.interpolate({
       inputRange: [0, 100],
       outputRange: [1, 1 + flipZoom],
-      extrapolate: "clamp"
+      extrapolate: 'clamp',
     });
 
     const scaling = {
-      transform: [{ scale: cardZoom }]
+      transform: [{ scale: cardZoom }],
     };
 
     return (
@@ -308,30 +309,30 @@ class CardFlip extends Component<Props> {
 const styles = StyleSheet.create({
   cardContainer: {
     flex: 1,
-    position: "absolute",
+    position: 'absolute',
     left: 0,
     right: 0,
     bottom: 0,
-    top: 0
-  }
+    top: 0,
+  },
 });
 
 CardFlip.defaultProps = {
   style: {},
   duration: 500,
   flipZoom: 0.09,
-  flipDirection: "y",
+  flipDirection: 'y',
   perspective: 800,
-  onFlip: () => { },
-  onFlipStart: () => { },
-  onFlipEnd: () => { }
+  onFlip: () => {},
+  onFlipStart: () => {},
+  onFlipEnd: () => {},
 };
 
 CardFlip.propTypes = {
   style: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.object,
-    PropTypes.array
+    PropTypes.array,
   ]),
   duration: PropTypes.number,
   flipZoom: PropTypes.number,
@@ -339,8 +340,8 @@ CardFlip.propTypes = {
   onFlip: PropTypes.func,
   onFlipEnd: PropTypes.func,
   onFlipStart: PropTypes.func,
-  perspective: PropTypes.number
+  perspective: PropTypes.number,
 };
 
-polyfill(CardFlip)
-export default CardFlip 
+polyfill(CardFlip);
+export default CardFlip;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-card-flip",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Card flip animation for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes an issue where the `bYRotation` variable which is conditionally set in the `getCardBTransformation` method is not instantiated and therefore cannot be redefined.

I also ran a linter on it, so let me know if you want me to revert those changes.