### PR TITLE
Fixes Issue#22

### DIFF
--- a/CardFlip.js
+++ b/CardFlip.js
@@ -243,7 +243,7 @@ class CardFlip extends Component<Props> {
       zIndex: side === 0 ? 0 : 1,
       transform: [{ perspective: -1 * this.props.perspective }]
     };
-
+    let bYRotation;
     if (rotateOrientation === "x") {
       const bXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],


### PR DESCRIPTION
The variable 'bYRotation' used in FlipCard.js was not defined above which still gives error while using the module on an android platform. This commit resolves this issue.