### PR TITLE
Adds property for reversing direction of the flip.

### DIFF
--- a/CardFlip.js
+++ b/CardFlip.js
@@ -198,7 +198,7 @@ class CardFlip extends Component<Props> {
 
   getCardATransformation() {
     //0, 50, 100
-    const { progress, rotation, side, rotateOrientation } = this.state;
+    const { progress, rotation, side, rotateOrientation, flipReverse } = this.state;
 
     const sideAOpacity = progress.interpolate({
       inputRange: [50, 51],
@@ -214,7 +214,7 @@ class CardFlip extends Component<Props> {
     if (rotateOrientation === "x") {
       const aXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: this.props.flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
+        outputRange: flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
         extrapolate: "clamp"
       });
       sideATransform.transform.push({ rotateX: aXRotation });
@@ -222,7 +222,7 @@ class CardFlip extends Component<Props> {
       // cardA Y-rotation
       const aYRotation = rotation.y.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: this.props.flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
+        outputRange: flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
         extrapolate: "clamp"
       });
       sideATransform.transform.push({ rotateY: aYRotation });
@@ -231,7 +231,7 @@ class CardFlip extends Component<Props> {
   }
 
   getCardBTransformation() {
-    const { progress, rotation, side, rotateOrientation } = this.state;
+    const { progress, rotation, side, rotateOrientation, flipReverse } = this.state;
 
     const sideBOpacity = progress.interpolate({
       inputRange: [50, 51],
@@ -248,7 +248,7 @@ class CardFlip extends Component<Props> {
     if (rotateOrientation === "x") {
       const bXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: this.props.flipReverse ? ["0deg", "180deg", "360deg", "-180deg"] : ["0deg", "-180deg", "-360deg", "180deg"],
+        outputRange: flipReverse ? ["0deg", "180deg", "360deg", "-180deg"] : ["0deg", "-180deg", "-360deg", "180deg"],
         extrapolate: "clamp"
       });
       sideBTransform.transform.push({ rotateX: bXRotation });
@@ -257,14 +257,14 @@ class CardFlip extends Component<Props> {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: this.props.flipReverse ? ["0deg", "-180deg", "0deg", "180deg"] : ["0deg", "180deg", "0deg", "-180deg"],
+          outputRange: flipReverse ? ["0deg", "-180deg", "0deg", "180deg"] : ["0deg", "180deg", "0deg", "-180deg"],
           extrapolate: "clamp"
         });
       } else {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: this.props.flipReverse ? ["0deg", "180deg", "0deg", "-180deg"] : ["0deg", "-180deg", "0deg", "180deg"],
+          outputRange: flipReverse ? ["0deg", "180deg", "0deg", "-180deg"] : ["0deg", "-180deg", "0deg", "180deg"],
           extrapolate: "clamp"
         });
       }

--- a/CardFlip.js
+++ b/CardFlip.js
@@ -15,7 +15,8 @@ class CardFlip extends Component<Props> {
       rotation: new Animated.ValueXY({ x: 50, y: 50 }),
       zoom: new Animated.Value(0),
       rotateOrientation: "",
-      flipDirection: "y"
+      flipDirection: "y",
+      flipReverse: false,
     }
   }
 
@@ -213,7 +214,7 @@ class CardFlip extends Component<Props> {
     if (rotateOrientation === "x") {
       const aXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["-180deg", "0deg", "180deg", "0deg"],
+        outputRange: this.props.flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
         extrapolate: "clamp"
       });
       sideATransform.transform.push({ rotateX: aXRotation });
@@ -221,7 +222,7 @@ class CardFlip extends Component<Props> {
       // cardA Y-rotation
       const aYRotation = rotation.y.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["-180deg", "0deg", "180deg", "0deg"],
+        outputRange: this.props.flipReverse ? ["180deg", "0deg", "-180deg", "0deg"] : ["-180deg", "0deg", "180deg", "0deg"],
         extrapolate: "clamp"
       });
       sideATransform.transform.push({ rotateY: aYRotation });
@@ -247,7 +248,7 @@ class CardFlip extends Component<Props> {
     if (rotateOrientation === "x") {
       const bXRotation = rotation.x.interpolate({
         inputRange: [0, 50, 100, 150],
-        outputRange: ["0deg", "-180deg", "-360deg", "180deg"],
+        outputRange: this.props.flipReverse ? ["0deg", "180deg", "360deg", "-180deg"] : ["0deg", "-180deg", "-360deg", "180deg"],
         extrapolate: "clamp"
       });
       sideBTransform.transform.push({ rotateX: bXRotation });
@@ -256,14 +257,14 @@ class CardFlip extends Component<Props> {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: ["0deg", "180deg", "0deg", "-180deg"],
+          outputRange: this.props.flipReverse ? ["0deg", "-180deg", "0deg", "180deg"] : ["0deg", "180deg", "0deg", "-180deg"],
           extrapolate: "clamp"
         });
       } else {
         // cardB Y-rotation
         bYRotation = rotation.y.interpolate({
           inputRange: [0, 50, 100, 150],
-          outputRange: ["0deg", "-180deg", "0deg", "180deg"],
+          outputRange: this.props.flipReverse ? ["0deg", "180deg", "0deg", "-180deg"] : ["0deg", "-180deg", "0deg", "180deg"],
           extrapolate: "clamp"
         });
       }
@@ -321,6 +322,7 @@ CardFlip.defaultProps = {
   duration: 500,
   flipZoom: 0.09,
   flipDirection: "y",
+  flipReverse: false,
   perspective: 800,
   onFlip: () => { },
   onFlipStart: () => { },
@@ -336,6 +338,7 @@ CardFlip.propTypes = {
   duration: PropTypes.number,
   flipZoom: PropTypes.number,
   flipDirection: PropTypes.string,
+  flipReverse: PropTypes.bool,
   onFlip: PropTypes.func,
   onFlipEnd: PropTypes.func,
   onFlipStart: PropTypes.func,

--- a/Example/App.js
+++ b/Example/App.js
@@ -16,12 +16,26 @@ const App: () => React$Node = () => {
           activeOpacity={1}
           style={[styles.card, styles.card1]}
           onPress={() => this.card.flip()}>
-          <Text style={styles.label}>AB</Text>
+          <Text style={styles.label}>Regular</Text>
         </TouchableOpacity>
         <TouchableOpacity
           activeOpacity={1}
           style={[styles.card, styles.card2]}
           onPress={() => this.card.flip()}>
+          <Text style={styles.label}>CD</Text>
+        </TouchableOpacity>
+      </CardFlip>
+      <CardFlip flipReverse style={[styles.cardContainer, {marginTop: 30}]} ref={card => (this.card2 = card)}>
+        <TouchableOpacity
+          activeOpacity={1}
+          style={[styles.card, styles.card1]}
+          onPress={() => this.card2.flip()}>
+          <Text style={styles.label}>flipReverse</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          activeOpacity={1}
+          style={[styles.card, styles.card2]}
+          onPress={() => this.card2.flip()}>
           <Text style={styles.label}>CD</Text>
         </TouchableOpacity>
       </CardFlip>

--- a/Example/package.json
+++ b/Example/package.json
@@ -13,7 +13,7 @@
     "react": "16.9.0",
     "react-lifecycles-compat": "^3.0.4",
     "react-native": "0.61.2",
-    "react-native-card-flip": "^1.0.4"
+    "react-native-card-flip": "../"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ import CardFlip from 'react-native-card-flip';
 | duration            | number        | flip duration                   |               | 1000          |
 | flipZoom            | number        | zoom level on flip              |               | 0.09          |
 | flipDirection       | string        | the rotation axis. 'x' or 'y'   |               | 'y'           |
+| flipReverse         | boolean       | reverses flip direction         |               | false         |
 | perspective         | number        |                                 |               | 800           |
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export type FlipCardProps = {
   duration?: number;
   flipZoom?: number;
   flipDirection?: FlipDirection;
+  flipReverse?: boolean;
   onFlip?: (index: number) => void;
   onFlipEnd?: (index: number) => void;
   onFlipStart?: (index: number) => void;


### PR DESCRIPTION
This allows the card to flip the opposite direction of default. Works on `x` & `y` `flipDirection`.

Includes an example in the example app.

Closes #7

![2020-06-24 11-15-47 2020-06-24 11_16_52](https://user-images.githubusercontent.com/139261/85583527-55965600-b60c-11ea-9def-c8789b71805d.gif)
